### PR TITLE
Added Clickable Links to GitHub Profile and Phone Number

### DIFF
--- a/Content.html
+++ b/Content.html
@@ -20,7 +20,10 @@
                     <br>
                     <i class="fa-solid fa-mobile"></i> 7880475746
                     <br>
-                    <i class="fa-brands fa-github">maazz-umar</i>
+                    <a href="https://github.com/maazz-umar" target="_blank">
+                        <i class="fa-brands fa-github"></i> maazz-umar
+                      </a>
+                      
                 </div>
             </div>
         </header>

--- a/Content.html
+++ b/Content.html
@@ -18,11 +18,14 @@
                 <div class="det">
                     <i class="fa-solid fa-envelope"></i> maazz.umar@gmail.com
                     <br>
-                    <i class="fa-solid fa-mobile"></i> 7880475746
+                    <a href="tel:7880475746">
+                        <i class="fa-solid fa-mobile"></i> 7880475746
+                    </a>
+                      
                     <br>
                     <a href="https://github.com/maazz-umar" target="_blank">
                         <i class="fa-brands fa-github"></i> maazz-umar
-                      </a>
+                    </a>
                       
                 </div>
             </div>


### PR DESCRIPTION

#### **1. Summary:**
This PR adds clickable links for the GitHub profile and phone number to the relevant sections of the webpage. The GitHub link redirects to the `maazz-umar` profile, while the phone number opens the phone dialer.

#### **2. Changes Made:**
- Added a clickable GitHub icon and profile link.
- Added a clickable phone icon and `tel:` link for the phone number.

#### **3. Testing:**
Tested the links by clicking on both the GitHub and phone number elements to ensure they work as expected.
